### PR TITLE
Fix multi-digit column indexes.

### DIFF
--- a/src/banks2ledger/core.clj
+++ b/src/banks2ledger/core.clj
@@ -337,7 +337,7 @@
 ;; return whitespace-trimmed version.
 (defn format-colspec [cols colspec]
   (-> colspec
-      (clojure.string/replace #"\%(\d)*"
+      (clojure.string/replace #"\%(\d*)"
              #(unquote-string (nth cols (Integer. (second %1)))))
       (clojure.string/trim)))
 

--- a/test/banks2ledger/core_test.clj
+++ b/test/banks2ledger/core_test.clj
@@ -297,7 +297,8 @@
     (is (= (format-colspec ["\"1st\"" "\"2nd\"" "\"3rd\""] "%0 %2") "1st 3rd"))
     (is (= (format-colspec ["1st" "2nd" "3rd"] "%1-%0-%2") "2nd-1st-3rd"))
     (is (= (format-colspec ["1st" "2nd" "   "] "%0 %2") "1st"))
-    (is (= (format-colspec ["1st" "2nd" "   "] "%0 %2 %1") "1st     2nd"))))
+    (is (= (format-colspec ["1st" "2nd" "   "] "%0 %2 %1") "1st     2nd"))
+    (is (= (format-colspec (vec (map str (range 1 12))) "%10") "11"))))
 
 (deftest test-get-col
   (testing "get-col"
@@ -307,7 +308,8 @@
     (is (= (get-col ["   " "2nd" "3rd"] "%0!%1!%2") "2nd"))
     (is (= (get-col ["   " "2nd" "3rd"] "%0 %2!%1") "3rd"))
     (is (= (get-col ["   " "2nd" "3rd"] "%0!%1%0%2!%2") "2nd   3rd"))
-    (is (= (get-col ["   " "2nd" "3rd"] "%0!%1%0!%2") "2nd"))))
+    (is (= (get-col ["   " "2nd" "3rd"] "%0!%1%0!%2") "2nd"))
+    (is (= (get-col (vec (map str (range 1 12))) "%10") "11"))))
 
 (deftest test-print-ledger-entry
   (testing "print-ledger-entry"


### PR DESCRIPTION
When specifying a multi-digit column index in the `-t` flag, it would use just the last digit (e.g. `%17` -> column 7). This fixes that.